### PR TITLE
fix: 객체 연관관계 맵핑 역전 이슈 (#2)

### DIFF
--- a/src/main/java/paldo_bottle/backend/DAO/Challenge.java
+++ b/src/main/java/paldo_bottle/backend/DAO/Challenge.java
@@ -15,17 +15,17 @@ import java.util.List;
 public class Challenge {
 
     @Id
-    private String  name;
-
-    @OneToMany(mappedBy = "challengeName")
-    private List<Achieve>   achieves;
+    private String name;
 
     @OneToMany(mappedBy = "challengeName", cascade = CascadeType.ALL)
-    private List<StampChallenge>    stampList;
+    private List<Achieve> achieves;
+
+    @OneToMany(mappedBy = "challengeName", cascade = CascadeType.ALL)
+    private List<StampChallenge> stampList;
 
     @Column
-    private String  description;
+    private String description;
 
     @Column
-    private Long    point;
+    private Long point;
 }

--- a/src/main/java/paldo_bottle/backend/DAO/OwnStamp.java
+++ b/src/main/java/paldo_bottle/backend/DAO/OwnStamp.java
@@ -9,6 +9,8 @@ import paldo_bottle.backend.DAO.identifier.OwnStampPK;
 import javax.persistence.*;
 import java.time.LocalDateTime;
 
+import static javax.persistence.FetchType.LAZY;
+
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -17,9 +19,9 @@ import java.time.LocalDateTime;
 @Table(name="user_own_stamp")
 public class OwnStamp {
     @Id
-    @ManyToOne
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name="id")
-    private User  userId;
+    private User userId;
 
     @Id
     @Column(name = "supDistrict", length = 200, nullable = false, insertable=false, updatable = false)
@@ -29,18 +31,18 @@ public class OwnStamp {
     @Column(name = "district", length = 200, nullable = false, insertable=false, updatable = false)
     private String district;
 
-    @ManyToOne
+    @ManyToOne(fetch = LAZY)
     @JoinColumns({
             @JoinColumn(name = "supDistrict", referencedColumnName = "supDistrict"),
             @JoinColumn(name = "district", referencedColumnName = "district")
     })
-    private Stamp  stamp;
+    private Stamp stamp;
 
     @Column
-    private LocalDateTime   publish_date;
+    private LocalDateTime publish_date;
 
     @Column
-    private Long            publish_number;
+    private Long publish_number;
 
 }
 

--- a/src/main/java/paldo_bottle/backend/DAO/Stamp.java
+++ b/src/main/java/paldo_bottle/backend/DAO/Stamp.java
@@ -27,7 +27,4 @@ public class Stamp {
 
     @OneToOne(mappedBy = "stamp")
     private Region region;
-
-//    @OneToMany(mappedBy = "stamp")
-//    private List<StampChallenge>    challengeList;
 }

--- a/src/main/java/paldo_bottle/backend/DAO/StampChallenge.java
+++ b/src/main/java/paldo_bottle/backend/DAO/StampChallenge.java
@@ -8,6 +8,8 @@ import paldo_bottle.backend.DAO.identifier.StampChallengePK;
 
 import javax.persistence.*;
 
+import static javax.persistence.FetchType.LAZY;
+
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor(access= AccessLevel.PROTECTED)
@@ -26,7 +28,7 @@ public class StampChallenge {
     private String district;
 
     @Id
-    @ManyToOne
+    @ManyToOne(fetch = LAZY)
     @JoinColumns({
             @JoinColumn(name = "supDistrict", referencedColumnName = "supDistrict"),
             @JoinColumn(name = "district", referencedColumnName = "district")

--- a/src/main/java/paldo_bottle/backend/DAO/User.java
+++ b/src/main/java/paldo_bottle/backend/DAO/User.java
@@ -16,13 +16,16 @@ import java.util.List;
 public class User {
 
     @Id @GeneratedValue
-    private String  id;
+    private String id;
 
-    @OneToMany(mappedBy = "userId")
-    private List<Achieve>   achieves;
+    @OneToMany(mappedBy = "userId", cascade = CascadeType.ALL)
+    private List<Achieve> achieves;
+
+    @OneToMany(mappedBy = "userId", cascade = CascadeType.ALL)
+    private List<OwnStamp> ownStamps;
 
     @Column
-    private Long    point;
+    private Long point;
     @Column
-    private String  address;
+    private String address;
 };


### PR DESCRIPTION
### 수정 사항 리스트
- @ManyToOne, @OneToOne 매핑 어노테이션에 (fetch = LAZY) 옵션 적용
- @OneToMany 매핑 어노테이션에 (cascade = CascadeType.ALL) 옵션 적용